### PR TITLE
Proposal: Expose isGlobal field

### DIFF
--- a/lib/agenda.module.ts
+++ b/lib/agenda.module.ts
@@ -26,6 +26,7 @@ export class AgendaService extends Agenda {}
 export class AgendaModule {
   static register(options: AgendaModuleOptions): DynamicModule {
     return {
+      isGlobal: options.isGlobal,
       module: AgendaModule,
       providers: createAgendaProvider(options),
     };
@@ -33,6 +34,7 @@ export class AgendaModule {
 
   static registerAsync(options: AgendaModuleAsyncOptions): DynamicModule {
     return {
+      isGlobal: options.isGlobal,
       module: AgendaModule,
       imports: options.imports || [],
       providers: this.createAsyncProviders(options),

--- a/lib/interfaces/agenda-module-options.interface.ts
+++ b/lib/interfaces/agenda-module-options.interface.ts
@@ -1,13 +1,16 @@
 import { ModuleMetadata, Type } from '@nestjs/common/interfaces';
 import * as Agenda from 'agenda';
 
-export interface AgendaModuleOptions extends Agenda.AgendaConfiguration {}
+export interface AgendaModuleOptions extends Agenda.AgendaConfiguration {
+  isGlobal: boolean,
+}
 
 export interface AgendaOptionsFactory {
   createAgendaOptions(): Promise<AgendaModuleOptions> | AgendaModuleOptions;
 }
 
 export interface AgendaModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  isGlobal: boolean,
   useExisting?: Type<AgendaOptionsFactory>;
   useClass?: Type<AgendaOptionsFactory>;
   useFactory?: (...args: any[]) => Promise<AgendaModuleOptions> | AgendaModuleOptions;


### PR DESCRIPTION
In this PR, I propose to expose `isGlobal` field in order to be able to declare this module as global module and import it once in AppModule.